### PR TITLE
se05x: fix policy configuration

### DIFF
--- a/sss/src/se05x/fsl_sss_se05x_policy.c
+++ b/sss/src/se05x/fsl_sss_se05x_policy.c
@@ -570,7 +570,6 @@ sss_status_t sss_se05x_create_object_policy_buffer(sss_policy_t *policies, uint8
                 default:
                     break;
                 }
-                policies->policies[indexArray[j]] = NULL;
             }
             memcpy(pbuff + offset, temp_buffer, (temp_buffer[0] + 1));
             *buf_len += (temp_buffer[0] + 1);


### PR DESCRIPTION
OP-TEE uses one global variable to define the asymmetric key object access policy. This global variable is passed to the Plug-and-Trust interface on every key generation request.

The Plug-and-Trust code is incorrectly altering/clearing that variable.

This causes that on the second request, there are not policies to apply

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>